### PR TITLE
Add Unichain network support

### DIFF
--- a/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/Chain.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/blockchains/ethereum/Chain.kt
@@ -99,4 +99,6 @@ enum class Chain(val id: Int, val blockchain: Blockchain?) {
     PepecoinTestnet(id = 63, blockchain = Blockchain.PepecoinTestnet), // TODO("Check chain id")
     Hyperliquid(id = 999, blockchain = Blockchain.Hyperliquid),
     HyperliquidTestnet(id = 998, blockchain = Blockchain.HyperliquidTestnet),
+    Unichain(id = 130, blockchain = Blockchain.Unichain),
+    UnichainTestnet(id = 1301, blockchain = Blockchain.UnichainTestnet),
 }

--- a/blockchain/src/main/java/com/tangem/blockchain/common/Blockchain.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/Blockchain.kt
@@ -205,6 +205,8 @@ enum class Blockchain(
     PepecoinTestnet("pepecoin/test", "PEP", "Pepecoin Testnet"),
     Hyperliquid("hyperliquid", "HYPE", "Hyperliquid EVM"),
     HyperliquidTestnet("hyperliquid/test", "HYPE", "Hyperliquid EVM Testnet"),
+    Unichain("unichain", "ETH", "Unichain"),
+    UnichainTestnet("unichain/test", "ETH", "Unichain Sepolia Testnet"),
     ;
 
     private val externalLinkProvider: ExternalLinkProvider by lazy { ExternalLinkProviderFactory.makeProvider(this) }
@@ -235,6 +237,7 @@ enum class Blockchain(
             Cyber,
             Scroll,
             ZkLinkNova,
+            Unichain,
             -> true
             else -> false
         }

--- a/blockchain/src/main/java/com/tangem/blockchain/common/BlockchainSdkConfig.kt
+++ b/blockchain/src/main/java/com/tangem/blockchain/common/BlockchainSdkConfig.kt
@@ -78,6 +78,7 @@ data class GetBlockCredentials(
     val sui: GetBlockAccessToken?,
     val telos: GetBlockAccessToken?,
     val tezos: GetBlockAccessToken?,
+    val unichain: GetBlockAccessToken?,
 )
 
 data class GetBlockAccessToken(


### PR DESCRIPTION
- Add Unichain and UnichainTestnet to Blockchain enum
- Add chain ID mappings: 130 for mainnet, 1301 for testnet
- Mark Unichain as L2 Ethereum network
- Add Unichain to GetBlockCredentials for RPC configuration

This enables Tangem wallet to support Unichain mainnet and testnet.